### PR TITLE
管理ポートフォリオ登録・一覧機能

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
         "@clerk/nextjs": "^6.19.4",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.49.8",
+        "axios": "^1.9.0",
         "next": "15.3.2",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-hook-form": "^7.56.4"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2149,6 +2151,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2171,6 +2178,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2272,7 +2289,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -2394,6 +2410,17 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/concat-map": {
@@ -2587,6 +2614,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2638,7 +2673,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -2751,7 +2785,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2760,7 +2793,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2796,7 +2828,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -2808,7 +2839,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -3490,6 +3520,25 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3503,6 +3552,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -3527,7 +3609,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3565,7 +3646,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -3589,7 +3669,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -3676,7 +3755,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3748,7 +3826,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3760,7 +3837,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -3775,7 +3851,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4691,7 +4766,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5309,6 +5383,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5394,6 +5473,21 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.56.4",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.4.tgz",
+      "integrity": "sha512-Rob7Ftz2vyZ/ZGsQZPaRdIefkgOSrQSPXfqBdvOPwJfoGnjwRJUs7EM7Kc1mcoDv3NOtqBzPGbcMB8CGn9CKgw==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "@clerk/nextjs": "^6.19.4",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.49.8",
+    "axios": "^1.9.0",
     "next": "15.3.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-hook-form": "^7.56.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,215 +1,155 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { createClient } from '@/utils/supabase/client'
+import { PortfolioWithRelations } from '@/types/portfolio'
+import { useAuth } from '@clerk/nextjs'
+import { StatsGrid, FilterType } from '@/components/dashboard/StatsGrid'
+import { PortfolioCardList } from '@/components/dashboard/PortfolioCardList'
 import Link from 'next/link'
 
-export default async function Dashboard() {
+export default function Dashboard() {
+  const [portfolios, setPortfolios] = useState<PortfolioWithRelations[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [currentFilter, setCurrentFilter] = useState<FilterType>('all')
+  const { userId, isLoaded, isSignedIn } = useAuth()
 
-  // サンプルのポートフォリオデータ（実際はデータベースから取得）
-  const portfolios = [
-    {
-      id: 1,
-      title: "Eコマースサイト",
-      description: "React + Next.js で作成したオンラインショップ",
-      technologies: ["React", "Next.js", "TypeScript", "Stripe"],
-      status: "公開中",
-      createdAt: "2024-01-15"
-    },
-    {
-      id: 2,
-      title: "タスク管理アプリ",
-      description: "チーム向けのタスク管理ツール",
-      technologies: ["Vue.js", "Node.js", "MongoDB"],
-      status: "開発中",
-      createdAt: "2024-02-03"
-    },
-    {
-      id: 3,
-      title: "ポートフォリオサイト",
-      description: "個人のポートフォリオウェブサイト",
-      technologies: ["Next.js", "Tailwind CSS", "Supabase"],
-      status: "公開中",
-      createdAt: "2024-02-20"
+  console.log('Auth state:', { userId, isLoaded, isSignedIn })
+
+  useEffect(() => {
+    const fetchPortfolios = async () => {
+      // 認証状態が読み込まれるまで待つ
+      if (!isLoaded) {
+        return
+      }
+
+      if (!isSignedIn || !userId) {
+        setError('認証が必要です')
+        setLoading(false)
+        return
+      }
+
+      try {
+        const supabase = createClient()
+
+        // ポートフォリオ一覧を取得（関連データも含む）
+        const { data, error: fetchError } = await supabase
+          .from('portfolios')
+          .select(
+            `
+            *,
+            features (id, name),
+            pages (id, name),
+            tech_stack (id, name, version)
+          `,
+          )
+          .order('created_at', { ascending: false })
+
+        if (fetchError) {
+          console.error('Portfolio fetch error:', fetchError)
+          setError('ポートフォリオの取得に失敗しました')
+        } else {
+          setPortfolios(data || [])
+          setError(null) // エラーをクリア
+        }
+      } catch (err) {
+        console.error('Failed to fetch portfolios:', err)
+        setError('ポートフォリオの取得に失敗しました')
+      } finally {
+        setLoading(false)
+      }
     }
-  ]
+
+    fetchPortfolios()
+  }, [userId, isLoaded, isSignedIn])
+
+  // 統計情報を計算
+  const publishedCount = portfolios.filter((p) => p.published !== false).length
+  const unpublishedCount = portfolios.filter(
+    (p) => p.published === false,
+  ).length
+
+  const handleFilterChange = (filter: FilterType) => {
+    setCurrentFilter(filter)
+  }
+
+  const handleClearFilter = () => {
+    setCurrentFilter('all')
+  }
+
+  if (loading || !isLoaded) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+          <p className="mt-4 text-gray-600 dark:text-gray-400">読み込み中...</p>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-
       {/* メインコンテンツ */}
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         <div className="px-4 py-6 sm:px-0">
-          
-          {/* ポートフォリオセクション */}
-          <div className="mb-8">
+          {/* エラー表示 */}
+          {error && (
+            <div className="mb-6 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+              {error}
+            </div>
+          )}
+
+          {/* ポートフォリオ一覧のヘッダー */}
+          {!error && (
             <div className="flex justify-between items-center mb-6">
               <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
                 ポートフォリオ一覧
               </h2>
               <Link
-                href="/dashboard/portfolios/new"
+                href="/admin/dashboard/portfolios/new"
                 className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
               >
-                <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                <svg
+                  className="w-4 h-4 mr-2"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 4v16m8-8H4"
+                  />
                 </svg>
                 ポートフォリオを追加
               </Link>
             </div>
-
-            {/* ポートフォリオ一覧 */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {portfolios.map((portfolio) => (
-                <div key={portfolio.id} className="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
-                  <div className="p-6">
-                    <div className="flex items-center justify-between mb-4">
-                      <h3 className="text-lg font-medium text-gray-900 dark:text-white">
-                        {portfolio.title}
-                      </h3>
-                      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                        portfolio.status === '公開中' 
-                          ? 'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-200'
-                          : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-200'
-                      }`}>
-                        {portfolio.status}
-                      </span>
-                    </div>
-                    
-                    <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                      {portfolio.description}
-                    </p>
-
-                    <div className="flex flex-wrap gap-2 mb-4">
-                      {portfolio.technologies.map((tech) => (
-                        <span
-                          key={tech}
-                          className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-200"
-                        >
-                          {tech}
-                        </span>
-                      ))}
-                    </div>
-
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs text-gray-500 dark:text-gray-400">
-                        作成日: {portfolio.createdAt}
-                      </span>
-                      <div className="flex space-x-2">
-                        <button className="text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium">
-                          編集
-                        </button>
-                        <button className="text-red-600 hover:text-red-500 dark:text-red-400 dark:hover:text-red-300 text-sm font-medium">
-                          削除
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            {/* 空の状態（ポートフォリオがない場合） */}
-            {portfolios.length === 0 && (
-              <div className="text-center py-12">
-                <svg className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-                </svg>
-                <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">
-                  ポートフォリオがありません
-                </h3>
-                <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                  最初のポートフォリオを追加して始めましょう。
-                </p>
-                <div className="mt-6">
-                  <Link
-                    href="/dashboard/portfolios/new"
-                    className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-                  >
-                    <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                    </svg>
-                    ポートフォリオを追加
-                  </Link>
-                </div>
-              </div>
-            )}
-
-          </div>
+          )}
 
           {/* 統計情報 */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
-              <div className="p-5">
-                <div className="flex items-center">
-                  <div className="flex-shrink-0">
-                    <div className="w-8 h-8 bg-blue-500 rounded-md flex items-center justify-center">
-                      <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-                      </svg>
-                    </div>
-                  </div>
-                  <div className="ml-5 w-0 flex-1">
-                    <dl>
-                      <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
-                        総ポートフォリオ数
-                      </dt>
-                      <dd className="text-lg font-medium text-gray-900 dark:text-white">
-                        {portfolios.length}
-                      </dd>
-                    </dl>
-                  </div>
-                </div>
-              </div>
-            </div>
+          {!error && (
+            <StatsGrid
+              totalCount={portfolios.length}
+              publishedCount={publishedCount}
+              unpublishedCount={unpublishedCount}
+              currentFilter={currentFilter}
+              onFilterChange={handleFilterChange}
+            />
+          )}
 
-            <div className="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
-              <div className="p-5">
-                <div className="flex items-center">
-                  <div className="flex-shrink-0">
-                    <div className="w-8 h-8 bg-green-500 rounded-md flex items-center justify-center">
-                      <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                    </div>
-                  </div>
-                  <div className="ml-5 w-0 flex-1">
-                    <dl>
-                      <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
-                        公開中
-                      </dt>
-                      <dd className="text-lg font-medium text-gray-900 dark:text-white">
-                        {portfolios.filter(p => p.status === '公開中').length}
-                      </dd>
-                    </dl>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
-              <div className="p-5">
-                <div className="flex items-center">
-                  <div className="flex-shrink-0">
-                    <div className="w-8 h-8 bg-yellow-500 rounded-md flex items-center justify-center">
-                      <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                    </div>
-                  </div>
-                  <div className="ml-5 w-0 flex-1">
-                    <dl>
-                      <dt className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
-                        開発中
-                      </dt>
-                      <dd className="text-lg font-medium text-gray-900 dark:text-white">
-                        {portfolios.filter(p => p.status === '開発中').length}
-                      </dd>
-                    </dl>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
+          {/* ポートフォリオ一覧 */}
+          {!error && (
+            <PortfolioCardList
+              portfolios={portfolios}
+              currentFilter={currentFilter}
+              onClearFilter={handleClearFilter}
+            />
+          )}
         </div>
       </main>
     </div>
   )
-} 
+}

--- a/src/app/admin/dashboard/portfolios/new/page.tsx
+++ b/src/app/admin/dashboard/portfolios/new/page.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { usePortfolioForm } from '@/hooks/usePortfolioForm'
+import { PortfolioForm } from '@/components/PortfolioForm'
+
+export default function NewPortfolioPage() {
+  const portfolioFormProps = usePortfolioForm()
+
+  return <PortfolioForm {...portfolioFormProps} />
+}

--- a/src/app/api/portfolios/route.ts
+++ b/src/app/api/portfolios/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+import { auth } from '@clerk/nextjs/server'
+import { CreatePortfolioRequest } from '@/types/portfolio'
+export async function POST(request: NextRequest) {
+  const { userId } = await auth()
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = await createClient()
+  const body: CreatePortfolioRequest = await request.json()
+
+  const rollback = async (portfolioId: string) => {
+    await supabase.from('tech_stack').delete().eq('portfolio_id', portfolioId)
+    await supabase.from('pages').delete().eq('portfolio_id', portfolioId)
+    await supabase.from('features').delete().eq('portfolio_id', portfolioId)
+    await supabase.from('portfolios').delete().eq('id', portfolioId)
+  }
+
+  const insertRelatedData = async <T>(
+    table: string,
+    data: T[],
+    rollbackFn: () => Promise<void>,
+    errorMessage: string,
+  ) => {
+    const { error } = await supabase.from(table).insert(data)
+    if (error) {
+      console.error(`${table} insert error:`, error)
+      await rollbackFn()
+      throw new Error(errorMessage)
+    }
+  }
+
+  try {
+    // ポートフォリオ挿入
+    const { data: portfolio, error: portfolioError } = await supabase
+      .from('portfolios')
+      .insert([body.portfolio])
+      .select()
+      .single()
+
+    if (portfolioError || !portfolio) {
+      throw new Error('Failed to create portfolio')
+    }
+
+    const portfolioId = portfolio.id
+
+    // features
+    if (body.features.length > 0) {
+      const features = body.features.map((name) => ({
+        portfolio_id: portfolioId,
+        name,
+      }))
+      await insertRelatedData(
+        'features',
+        features,
+        async () => {
+          await supabase.from('portfolios').delete().eq('id', portfolioId)
+        },
+        'Failed to create features',
+      )
+    }
+
+    // pages
+    if (body.pages.length > 0) {
+      const pages = body.pages.map((name) => ({
+        portfolio_id: portfolioId,
+        name,
+      }))
+      await insertRelatedData(
+        'pages',
+        pages,
+        async () => {
+          await supabase
+            .from('features')
+            .delete()
+            .eq('portfolio_id', portfolioId)
+          await supabase.from('portfolios').delete().eq('id', portfolioId)
+        },
+        'Failed to create pages',
+      )
+    }
+
+    // tech_stack
+    if (body.techStack.length > 0) {
+      const techStack = body.techStack.map((tech) => ({
+        portfolio_id: portfolioId,
+        name: tech.name,
+        version: tech.version || null,
+      }))
+      await insertRelatedData(
+        'tech_stack',
+        techStack,
+        async () => {
+          await rollback(portfolioId)
+        },
+        'Failed to create tech stack',
+      )
+    }
+
+    return NextResponse.json(
+      {
+        message: 'Portfolio created successfully',
+        portfolio,
+      },
+      { status: 201 },
+    )
+  } catch (error) {
+    console.error('API Error:', error)
+    return NextResponse.json(
+      { error: (error as Error).message || 'Internal server error' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/PortfolioForm.tsx
+++ b/src/components/PortfolioForm.tsx
@@ -1,0 +1,362 @@
+import Link from 'next/link'
+import { UsePortfolioFormReturn } from '@/hooks/usePortfolioForm'
+
+type PortfolioFormProps = UsePortfolioFormReturn
+
+export const PortfolioForm = ({
+  form,
+  featureFields,
+  pageFields,
+  techStackFields,
+  onSubmit,
+}: PortfolioFormProps) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { isSubmitting },
+  } = form
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 py-8">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* ヘッダー */}
+        <div className="mb-8">
+          <Link
+            href="/admin/dashboard"
+            className="text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300 font-medium"
+          >
+            ← ダッシュボードに戻る
+          </Link>
+          <h1 className="mt-4 text-2xl font-bold text-gray-900 dark:text-white">
+            ポートフォリオを追加
+          </h1>
+        </div>
+
+        {/* フォーム */}
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
+          {/* 基本情報 */}
+          <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-6">
+              基本情報
+            </h2>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  プロジェクト名
+                </label>
+                <input
+                  {...register('name')}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  開発期間
+                </label>
+                <input
+                  {...register('period')}
+                  placeholder="例：2024年1月〜3月"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+            </div>
+
+            <div className="mt-6">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                プロジェクト説明
+              </label>
+              <textarea
+                {...register('description')}
+                rows={4}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+
+            <div className="mt-6">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                こだわった部分
+              </label>
+              <textarea
+                {...register('highlights')}
+                rows={3}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+
+            <div className="mt-6">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                苦労した部分
+              </label>
+              <textarea
+                {...register('challenges')}
+                rows={3}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+
+            <div className="mt-6">
+              <label className="flex items-center">
+                <input
+                  {...register('published')}
+                  type="checkbox"
+                  className="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50"
+                />
+                <span className="ml-2 text-sm text-gray-700 dark:text-gray-300">
+                  公開する
+                </span>
+              </label>
+            </div>
+          </div>
+
+          {/* リンク情報 */}
+          <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-6">
+              リンク情報
+            </h2>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  デモURL
+                </label>
+                <input
+                  {...register('url')}
+                  type="url"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  GitHub URL
+                </label>
+                <input
+                  {...register('github_url')}
+                  type="url"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  ブログURL
+                </label>
+                <input
+                  {...register('blog_url')}
+                  type="url"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 画像・動画URL */}
+          <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <h2 className="text-lg font-medium text-gray-900 dark:text-white mb-6">
+              画像・動画URL
+            </h2>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  サムネイル画像URL
+                </label>
+                <input
+                  {...register('thumbnail')}
+                  type="url"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  デモ動画URL
+                </label>
+                <input
+                  {...register('demo_video')}
+                  type="url"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  画像1 URL
+                </label>
+                <input
+                  {...register('image1')}
+                  type="url"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  画像2 URL
+                </label>
+                <input
+                  {...register('image2')}
+                  type="url"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  画像3 URL
+                </label>
+                <input
+                  {...register('image3')}
+                  type="url"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  画像4 URL
+                </label>
+                <input
+                  {...register('image4')}
+                  type="url"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 機能 */}
+          <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <div className="flex justify-between items-center mb-6">
+              <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+                機能
+              </h2>
+              <button
+                type="button"
+                onClick={() => featureFields.append({ name: '' })}
+                className="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+              >
+                + 追加
+              </button>
+            </div>
+
+            {featureFields.fields.map((field, index) => (
+              <div key={field.id} className="flex gap-2 mb-2">
+                <input
+                  {...register(`features.${index}.name` as const)}
+                  placeholder="機能名"
+                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+                {featureFields.fields.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => featureFields.remove(index)}
+                    className="px-3 py-2 text-red-600 hover:text-red-500"
+                  >
+                    削除
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* ページ */}
+          <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <div className="flex justify-between items-center mb-6">
+              <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+                ページ
+              </h2>
+              <button
+                type="button"
+                onClick={() => pageFields.append({ name: '' })}
+                className="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+              >
+                + 追加
+              </button>
+            </div>
+
+            {pageFields.fields.map((field, index) => (
+              <div key={field.id} className="flex gap-2 mb-2">
+                <input
+                  {...register(`pages.${index}.name` as const)}
+                  placeholder="ページ名"
+                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+                {pageFields.fields.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => pageFields.remove(index)}
+                    className="px-3 py-2 text-red-600 hover:text-red-500"
+                  >
+                    削除
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* 技術スタック */}
+          <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+            <div className="flex justify-between items-center mb-6">
+              <h2 className="text-lg font-medium text-gray-900 dark:text-white">
+                技術スタック
+              </h2>
+              <button
+                type="button"
+                onClick={() =>
+                  techStackFields.append({ name: '', version: '' })
+                }
+                className="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+              >
+                + 追加
+              </button>
+            </div>
+
+            {techStackFields.fields.map((field, index) => (
+              <div key={field.id} className="flex gap-2 mb-2">
+                <input
+                  {...register(`techStack.${index}.name` as const)}
+                  placeholder="技術名"
+                  className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+                <input
+                  {...register(`techStack.${index}.version` as const)}
+                  placeholder="バージョン（オプション）"
+                  className="w-32 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                />
+                {techStackFields.fields.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => techStackFields.remove(index)}
+                    className="px-3 py-2 text-red-600 hover:text-red-500"
+                  >
+                    削除
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* 送信ボタン */}
+          <div className="flex gap-4">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? '作成中...' : 'ポートフォリオを作成'}
+            </button>
+            <Link
+              href="/admin/dashboard"
+              className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              キャンセル
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/PortfolioCard.tsx
+++ b/src/components/dashboard/PortfolioCard.tsx
@@ -1,0 +1,116 @@
+import { PortfolioWithRelations } from '@/types/portfolio'
+
+type PortfolioCardProps = {
+  portfolio: PortfolioWithRelations
+}
+
+export const PortfolioCard = ({ portfolio }: PortfolioCardProps) => {
+  return (
+    <div className="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
+      {/* サムネイル画像 */}
+      {/* {portfolio.thumbnail && (
+        <div className="h-48 bg-gray-200 dark:bg-gray-700">
+          <img
+            src={portfolio.thumbnail}
+            alt={portfolio.name}
+            className="w-full h-full object-cover"
+            onError={(e) => {
+              e.currentTarget.style.display = 'none'
+            }}
+          />
+        </div>
+      )} */}
+
+      <div className="p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-medium text-gray-900 dark:text-white truncate">
+            {portfolio.name}
+          </h3>
+          <span
+            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+              portfolio.published !== false
+                ? 'bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-200'
+                : 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200'
+            }`}
+          >
+            {portfolio.published !== false ? '公開中' : '非公開'}
+          </span>
+        </div>
+
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4 line-clamp-3">
+          {portfolio.description}
+        </p>
+
+        {/* リンク */}
+        <div className="flex gap-2 mb-4">
+          {portfolio.url && (
+            <a
+              href={portfolio.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-200 hover:bg-blue-200 dark:hover:bg-blue-700"
+            >
+              <svg
+                className="w-3 h-3 mr-1"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                />
+              </svg>
+              Demo
+            </a>
+          )}
+          {portfolio.github_url && (
+            <a
+              href={portfolio.github_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700"
+            >
+              <svg
+                className="w-3 h-3 mr-1"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+              GitHub
+            </a>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+          <div>
+            <div>
+              作成:{' '}
+              {portfolio.created_at
+                ? new Date(portfolio.created_at).toLocaleDateString('ja-JP')
+                : '不明'}
+            </div>
+            {portfolio.updated_at &&
+              portfolio.updated_at !== portfolio.created_at && (
+                <div>
+                  更新:{' '}
+                  {new Date(portfolio.updated_at).toLocaleDateString('ja-JP')}
+                </div>
+              )}
+          </div>
+          <div className="flex space-x-2">
+            <button className="text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium">
+              編集
+            </button>
+            <button className="text-red-600 hover:text-red-500 dark:text-red-400 dark:hover:text-red-300 text-sm font-medium">
+              削除
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/PortfolioCardList.tsx
+++ b/src/components/dashboard/PortfolioCardList.tsx
@@ -1,0 +1,102 @@
+import Link from 'next/link'
+import { PortfolioWithRelations } from '@/types/portfolio'
+import { PortfolioCard } from './PortfolioCard'
+import { FilterType } from './StatsGrid'
+
+type PortfolioCardListProps = {
+  portfolios: PortfolioWithRelations[]
+  currentFilter: FilterType
+  onClearFilter: () => void
+}
+
+export const PortfolioCardList = ({
+  portfolios,
+  currentFilter,
+}: PortfolioCardListProps) => {
+  // フィルタに基づいてポートフォリオをフィルタリング
+  const filteredPortfolios = portfolios.filter((portfolio) => {
+    if (currentFilter === 'all') return true
+    if (currentFilter === 'published') return portfolio.published !== false
+    if (currentFilter === 'unpublished') return portfolio.published === false
+    return true
+  })
+
+  return (
+    <div className="mb-8">
+      {/* ポートフォリオ一覧 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {filteredPortfolios.map((portfolio) => (
+          <PortfolioCard key={portfolio.id} portfolio={portfolio} />
+        ))}
+      </div>
+
+      {/* 空の状態（ポートフォリオがない場合） */}
+      {filteredPortfolios.length === 0 && portfolios.length > 0 && (
+        <div className="text-center py-12">
+          <svg
+            className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">
+            該当するポートフォリオがありません
+          </h3>
+        </div>
+      )}
+
+      {/* 完全に空の状態（ポートフォリオが存在しない場合） */}
+      {portfolios.length === 0 && (
+        <div className="text-center py-12">
+          <svg
+            className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+            />
+          </svg>
+          <h3 className="mt-2 text-sm font-medium text-gray-900 dark:text-white">
+            ポートフォリオがありません
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            最初のポートフォリオを追加して始めましょう。
+          </p>
+          <div className="mt-6">
+            <Link
+              href="/admin/dashboard/portfolios/new"
+              className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              <svg
+                className="w-4 h-4 mr-2"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 4v16m8-8H4"
+                />
+              </svg>
+              ポートフォリオを追加
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/dashboard/StatCard.tsx
+++ b/src/components/dashboard/StatCard.tsx
@@ -1,0 +1,39 @@
+type StatCardProps = {
+  title: string
+  value: number
+  icon: React.ReactNode
+  colorClass: string
+  onClick?: () => void
+}
+
+export const StatCard = ({
+  title,
+  value,
+  icon,
+  colorClass,
+  onClick,
+}: StatCardProps) => {
+  return (
+    <div
+      className={`${colorClass} rounded-xl p-6 text-white shadow-lg cursor-pointer hover:shadow-xl transition-shadow duration-200`}
+      onClick={onClick}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <div className="p-2 bg-white/20 rounded-lg">{icon}</div>
+          <div>
+            <p className="text-white/80 text-sm font-medium">{title}</p>
+            <p className="text-3xl font-bold">{value}</p>
+          </div>
+        </div>
+
+        {/* 装飾的な要素 - 小さく右端に */}
+        <div className="opacity-10">
+          <div className="w-8 h-8 rounded-full bg-white/20 flex items-center justify-center">
+            <div className="text-sm">{icon}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/dashboard/StatsGrid.tsx
+++ b/src/components/dashboard/StatsGrid.tsx
@@ -1,0 +1,68 @@
+import { StatCard } from './StatCard'
+import { FolderIcon, CheckCircleIcon, EyeOffIcon } from './icons'
+
+export type FilterType = 'all' | 'published' | 'unpublished'
+
+type StatsGridProps = {
+  totalCount: number
+  publishedCount: number
+  unpublishedCount: number
+  currentFilter: FilterType
+  onFilterChange: (filter: FilterType) => void
+}
+
+export const StatsGrid = ({
+  totalCount,
+  publishedCount,
+  unpublishedCount,
+  currentFilter,
+  onFilterChange,
+}: StatsGridProps) => {
+  const stats = [
+    {
+      title: '総ポートフォリオ数',
+      value: totalCount,
+      icon: <FolderIcon />,
+      colorClass:
+        currentFilter === 'all'
+          ? 'bg-gradient-to-br from-blue-600 to-blue-700 ring-2 ring-blue-300'
+          : 'bg-gradient-to-br from-blue-500 to-blue-600',
+      filter: 'all' as FilterType,
+    },
+    {
+      title: '公開中',
+      value: publishedCount,
+      icon: <CheckCircleIcon />,
+      colorClass:
+        currentFilter === 'published'
+          ? 'bg-gradient-to-br from-green-600 to-green-700 ring-2 ring-green-300'
+          : 'bg-gradient-to-br from-green-500 to-green-600',
+      filter: 'published' as FilterType,
+    },
+    {
+      title: '非公開',
+      value: unpublishedCount,
+      icon: <EyeOffIcon />,
+      colorClass:
+        currentFilter === 'unpublished'
+          ? 'bg-gradient-to-br from-orange-600 to-orange-700 ring-2 ring-orange-300'
+          : 'bg-gradient-to-br from-orange-500 to-orange-600',
+      filter: 'unpublished' as FilterType,
+    },
+  ]
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+      {stats.map((stat, index) => (
+        <StatCard
+          key={index}
+          title={stat.title}
+          value={stat.value}
+          icon={stat.icon}
+          colorClass={stat.colorClass}
+          onClick={() => onFilterChange(stat.filter)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/dashboard/icons.tsx
+++ b/src/components/dashboard/icons.tsx
@@ -1,0 +1,63 @@
+export const FolderIcon = () => (
+  <svg
+    className="w-5 h-5 text-white"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+    />
+  </svg>
+)
+
+export const CheckCircleIcon = () => (
+  <svg
+    className="w-5 h-5 text-white"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+    />
+  </svg>
+)
+
+export const ClockIcon = () => (
+  <svg
+    className="w-5 h-5 text-white"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+    />
+  </svg>
+)
+
+export const EyeOffIcon = () => (
+  <svg
+    className="w-5 h-5 text-white"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L3 3m6.878 6.878L21 21"
+    />
+  </svg>
+)

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,0 +1,6 @@
+export { StatsGrid } from './StatsGrid'
+export type { FilterType } from './StatsGrid'
+export { StatCard } from './StatCard'
+export { PortfolioCard } from './PortfolioCard'
+export { PortfolioCardList } from './PortfolioCardList'
+export { FolderIcon, CheckCircleIcon, EyeOffIcon } from './icons'

--- a/src/hooks/usePortfolioForm.ts
+++ b/src/hooks/usePortfolioForm.ts
@@ -1,0 +1,110 @@
+import {
+  useForm,
+  useFieldArray,
+  UseFormReturn,
+  UseFieldArrayReturn,
+} from 'react-hook-form'
+import { useRouter } from 'next/navigation'
+import { PortfolioFormData, CreatePortfolioRequest } from '@/types/portfolio'
+import { PortfolioService } from '@/services/portfolioService'
+
+export type UsePortfolioFormReturn = {
+  form: UseFormReturn<PortfolioFormData>
+  featureFields: UseFieldArrayReturn<PortfolioFormData, 'features', 'id'>
+  pageFields: UseFieldArrayReturn<PortfolioFormData, 'pages', 'id'>
+  techStackFields: UseFieldArrayReturn<PortfolioFormData, 'techStack', 'id'>
+  onSubmit: (data: PortfolioFormData) => Promise<void>
+}
+
+export const usePortfolioForm = (): UsePortfolioFormReturn => {
+  const router = useRouter()
+
+  const form = useForm<PortfolioFormData>({
+    defaultValues: {
+      name: '',
+      thumbnail: '',
+      demo_video: '',
+      url: '',
+      github_url: '',
+      blog_url: '',
+      image1: '',
+      image2: '',
+      image3: '',
+      image4: '',
+      description: '',
+      period: '',
+      highlights: '',
+      challenges: '',
+      published: true,
+      features: [{ name: '' }],
+      pages: [{ name: '' }],
+      techStack: [{ name: '', version: '' }],
+    },
+  })
+
+  const featureFields = useFieldArray({
+    control: form.control,
+    name: 'features',
+  })
+
+  const pageFields = useFieldArray({
+    control: form.control,
+    name: 'pages',
+  })
+
+  const techStackFields = useFieldArray({
+    control: form.control,
+    name: 'techStack',
+  })
+
+  const onSubmit = async (data: PortfolioFormData) => {
+    try {
+      // データを整形（ファイルアップロード機能は削除）
+      const requestData: CreatePortfolioRequest = {
+        portfolio: {
+          name: data.name,
+          thumbnail: data.thumbnail || null,
+          demo_video: data.demo_video || null,
+          url: data.url || null,
+          github_url: data.github_url || null,
+          blog_url: data.blog_url || null,
+          image1: data.image1 || null,
+          image2: data.image2 || null,
+          image3: data.image3 || null,
+          image4: data.image4 || null,
+          description: data.description,
+          period: data.period,
+          highlights: data.highlights,
+          challenges: data.challenges,
+          published: data.published,
+        },
+        features: data.features
+          .filter((f) => f.name.trim() !== '')
+          .map((f) => f.name),
+        pages: data.pages
+          .filter((p) => p.name.trim() !== '')
+          .map((p) => p.name),
+        techStack: data.techStack
+          .filter((t) => t.name.trim() !== '')
+          .map((t) => ({
+            name: t.name,
+            version: t.version || undefined,
+          })),
+      }
+
+      await PortfolioService.createPortfolio(requestData)
+      router.push('/admin/dashboard')
+    } catch (error) {
+      console.error('Error creating portfolio:', error)
+      alert('ポートフォリオの作成に失敗しました')
+    }
+  }
+
+  return {
+    form,
+    featureFields,
+    pageFields,
+    techStackFields,
+    onSubmit,
+  }
+}

--- a/src/services/portfolioService.ts
+++ b/src/services/portfolioService.ts
@@ -1,0 +1,9 @@
+import axios from 'axios'
+import { CreatePortfolioRequest } from '@/types/portfolio'
+
+export class PortfolioService {
+  static async createPortfolio(data: CreatePortfolioRequest) {
+    const response = await axios.post('/api/portfolios', data)
+    return response.data
+  }
+}

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -1,0 +1,84 @@
+export type Portfolio = {
+  id?: number
+  name: string
+  thumbnail: string | null
+  demo_video: string | null
+  url: string | null
+  github_url: string | null
+  blog_url: string | null
+  image1: string | null
+  image2: string | null
+  image3: string | null
+  image4: string | null
+  description: string
+  period: string
+  highlights: string
+  challenges: string
+  published?: boolean
+  created_at?: string
+  updated_at?: string
+}
+
+export type Feature = {
+  id?: number
+  portfolio_id: number
+  name: string
+  created_at?: string
+  updated_at?: string
+}
+
+export type Page = {
+  id?: number
+  portfolio_id: number
+  name: string
+  created_at?: string
+  updated_at?: string
+}
+
+export type TechStack = {
+  id?: number
+  portfolio_id: number
+  name: string
+  version: string | null
+  created_at?: string
+  updated_at?: string
+}
+
+// 関連データを含むポートフォリオの型
+export type PortfolioWithRelations = Portfolio & {
+  features: Pick<Feature, 'id' | 'name'>[]
+  pages: Pick<Page, 'id' | 'name'>[]
+  tech_stack: Pick<TechStack, 'id' | 'name' | 'version'>[]
+}
+
+export type CreatePortfolioRequest = {
+  portfolio: Omit<Portfolio, 'id' | 'created_at' | 'updated_at'>
+  features: string[]
+  pages: string[]
+  techStack: Array<{
+    name: string
+    version?: string
+  }>
+}
+
+// React Hook Form用の型定義
+export type PortfolioFormData = {
+  name: string
+  thumbnail: string
+  demo_video: string
+  url: string
+  github_url: string
+  blog_url: string
+  image1: string
+  image2: string
+  image3: string
+  image4: string
+  description: string
+  period: string
+  highlights: string
+  challenges: string
+  published: boolean
+  features: Array<{ name: string }>
+  pages: Array<{ name: string }>
+  techStack: Array<{ name: string; version: string }>
+}


### PR DESCRIPTION
## 概要

管理側のポートフォリオ登録・一覧機能実装

## 関連するissue番号

- #8 
- #11 

## 行ったこと

- axiosとreact-hook-formインストール
- Supabaseでportfoliios、features、pages、tech_stacksテーブル作成
- 管理ポートフォリオ登録フォーム作成
- 管理ポートフォリオ登録機能作成
- ダッシュボードでポートフォリオ一覧表示
- 管理ポートフォリオ一覧取得機能作成
- 公開・非公開のポートフォリオ一覧を切り替える機能作成

## 動作確認

管理ポートフォリオ登録フォーム http://localhost:3000/admin/dashboard/portfolios/new
ダッシュボード http://localhost:3000/admin/dashboard

## その他

登録時のバリデーション、画像・動画アップロード未対応
一覧でのサムネイル画像の表示未対応
